### PR TITLE
[fix] the `json` method is deprecated bug

### DIFF
--- a/ochat/serving/openai_api_server.py
+++ b/ochat/serving/openai_api_server.py
@@ -206,7 +206,7 @@ async def create_chat_completion(raw_request: Request, background_tasks: Backgro
             model=model_name,
         )
 
-        return response.json(exclude_unset=True, ensure_ascii=False)
+        return response.model_dump_json(exclude_unset=True)
 
     async def completion_stream_generator() -> AsyncGenerator[str, None]:
         # First chunk with role
@@ -220,7 +220,7 @@ async def create_chat_completion(raw_request: Request, background_tasks: Backgro
                                                                      choices=[choice_data],
                                                                      model=model_name)
 
-            yield f"data: {chunk.json(exclude_unset=True, ensure_ascii=False)}\n\n"
+            yield f"data: {chunk.model_dump_json(exclude_unset=True)}\n\n"
 
         previous_texts = [""] * request.n
         previous_num_tokens = [0] * request.n


### PR DESCRIPTION
In some request met this error:
PydanticDeprecatedSince20: The `json` method is deprecated; use `model_dump_json` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.5/migration/